### PR TITLE
Importupdate

### DIFF
--- a/api/src/afvalcontainers/models.py
+++ b/api/src/afvalcontainers/models.py
@@ -21,9 +21,8 @@ from django.contrib.postgres.fields import JSONField
 
 
 class Container(models.Model):
-    """
-    Container object
-    """
+    """Container object."""
+
     id = models.IntegerField(primary_key=True)
     id_number = models.CharField(max_length=35, null=False, db_index=True)
     serial_number = models.CharField(max_length=45, null=False, db_index=True)
@@ -76,9 +75,8 @@ class Container(models.Model):
 
 
 class Well(models.Model):
-    """
-    Wells contain containers
-    """
+    """Wells contain containers."""
+
     id = models.IntegerField(primary_key=True)
     id_number = models.CharField(max_length=35, db_index=True)
     serial_number = models.CharField(max_length=45, db_index=True)
@@ -121,8 +119,7 @@ class Site(models.Model):
     bgt_based = models.NullBooleanField()
     centroid = models.PointField(name='centroid', srid=4326)
     geometrie = models.PolygonField(name='geometrie', srid=28992)
-
-    extra_attributes = JSONField(null=True)
+    extra_attributes = JSONField(null=True, default=dict)
 
     def __str__(self):
         return f"{self.id}-{self.straatnaam} {self.huisnummer}"
@@ -138,9 +135,8 @@ class Site(models.Model):
 
 
 class ContainerType(models.Model):
-    """
-    Contains volumne information aboud containers
-    """
+    """Contains volumne information aboud containers."""
+
     id = models.IntegerField(primary_key=True)
     name = models.TextField()
     volume = models.IntegerField()

--- a/api/src/afvalcontainers/tests/factories.py
+++ b/api/src/afvalcontainers/tests/factories.py
@@ -69,7 +69,7 @@ class SiteFactory(factory.DjangoModelFactory):
     buurt_code = fuzzy.FuzzyText(length=4)
     stadsdeel = fuzzy.FuzzyText(length=1)
     straatnaam = fuzzy.FuzzyText(length=10)
-
+    short_id = fuzzy.FuzzyInteger(1, 9200)
     huisnummer = fuzzy.FuzzyInteger(1, 92)
 
     centroid = get_puntje()

--- a/api/src/afvalcontainers/tests/test_api.py
+++ b/api/src/afvalcontainers/tests/test_api.py
@@ -1,7 +1,10 @@
 # Packages
+
 from rest_framework.test import APITestCase
 
 from . import factories
+
+# import logging
 
 
 class BrowseDatasetsTestCase(APITestCase):
@@ -23,12 +26,12 @@ class BrowseDatasetsTestCase(APITestCase):
         self.s = factories.SiteFactory()
         self.w.site_id = self.s.id
         self.w.save()
+        self.snull = factories.SiteFactory()
+        self.snull.short_id = None
+        self.snull.save()
 
     def valid_response(self, url, response, content_type):
-        """
-        Helper method to check common status/json
-        """
-
+        """Check common status/json."""
         self.assertEqual(
             200, response.status_code, "Wrong response code for {}".format(url)
         )
@@ -100,3 +103,17 @@ class BrowseDatasetsTestCase(APITestCase):
             self.assertIn(
                 "count", response.data, "No count attribute in {}".format(url)
             )
+
+    def test_site_filters(self):
+        url = "afval/sites"
+        response = self.client.get(f"/{url}/", {'short_id': self.s.short_id})
+        self.valid_response(url, response, 'application/json')
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(int(response.data['results'][0]['id']), self.s.id)
+
+    def test_site_null_filter(self):
+        url = "afval/sites"
+        response = self.client.get(f"/{url}/", {'no_short_id': 1})
+        self.valid_response(url, response, 'application/json')
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(int(response.data['results'][0]['id']), self.snull.id)

--- a/api/src/afvalcontainers/views.py
+++ b/api/src/afvalcontainers/views.py
@@ -59,7 +59,7 @@ class ContainerFilter(FilterSet):
     in_bbox = filters.CharFilter(method='in_bbox_filter', label='bbox')
     no_well = filters.BooleanFilter(method='no_well_filter', label='no_well')
     location = filters.CharFilter(
-            method="locatie_filter", label='x,y,r')
+        method="locatie_filter", label='x,y,r')
 
     waste_name = filters.ChoiceFilter(
         choices=WASTE_CHOICES, label='waste name')
@@ -110,8 +110,8 @@ class ContainerFilter(FilterSet):
 
 
 class ContainerView(DatapuntViewSet):
-    """View of Containers.
-    """
+    """View of Containers."""
+
     queryset = (
         Container.objects.all()
         .order_by("id")
@@ -196,8 +196,8 @@ class WellFilter(FilterSet):
 
 
 class WellView(DatapuntViewSet):
-    """View of Wells.
-    """
+    """View of Wells."""
+
     queryset = (
         Well.objects.all()
         .order_by("id")
@@ -210,8 +210,8 @@ class WellView(DatapuntViewSet):
 
 
 class TypeView(DatapuntViewSet):
-    """View of Types.
-    """
+    """View of Types."""
+
     queryset = (
         ContainerType.objects.all()
         .order_by("id")
@@ -232,6 +232,9 @@ class SiteFilter(FilterSet):
 
     no_container = filters.BooleanFilter(
         method='no_container_filter', label='No containers')
+
+    no_short_id = filters.BooleanFilter(
+        method='no_short_id_filter', label='Missing short_id ')
 
     location = filters.CharFilter(
         method="locatie_filter", label='x,y,r')
@@ -258,6 +261,7 @@ class SiteFilter(FilterSet):
             "bgt_based",
             "no_container",
             "fractie",
+            "no_short_id",
         )
 
     def locatie_filter(self, qs, name, value):
@@ -279,16 +283,17 @@ class SiteFilter(FilterSet):
     def no_container_filter(self, qs, name, value):
         return qs.filter(wells__containers=None)
 
+    def no_short_id_filter(self, qs, name, value):
+        return qs.filter(short_id=None)
+
     def fractie_filter(self, qs, name, value):
-        """
-        Filter on fractie.
-        """
+        """Filter on fractie."""
         return qs.filter(wells__containers__waste_name=value).distinct()
 
 
 class SitePager(HALPagination):
-    """Site objects are rather "heavy" so put limits on pagination
-    """
+    """Site objects are rather "heavy" so put limits on pagination."""
+
     page_size = 10
     max_page_size = 9000
 

--- a/scrape_api/README.rst
+++ b/scrape_api/README.rst
@@ -37,9 +37,9 @@ set env `BAMMENS_PASSWORD` you can find it in rattic/password management
 # occur!
 
 ::
-        python slurp_api.py containers
-        python slurp_api.py wells
-        python slurp_api.py containertypes
+        python slurp_bammens.py containers
+        python slurp_bammens.py wells
+        python slurp_bammens.py containertypes
 
 # takes about 30 mins.
 

--- a/scrape_api/create_sites.py
+++ b/scrape_api/create_sites.py
@@ -522,13 +522,6 @@ if __name__ == "__main__":
     )
 
     inputparser.add_argument(
-        "--short_ids",
-        default=False,
-        action="store_true",
-        help="create short ids",
-    )
-
-    inputparser.add_argument(
         "--debug", action="store_true", default=False, help="Enable debugging"
     )
 

--- a/scrape_api/deploy/import/import.sh
+++ b/scrape_api/deploy/import/import.sh
@@ -40,9 +40,9 @@ dc run --rm importer python models.py
 dc run --rm importer python load_wfs_postgres.py https://map.data.amsterdam.nl/maps/gebieden buurt_simple,stadsdeel 28992
 
 # Importeer bammens api endpoints
-dc run --rm importer python slurp_api.py container_types
-dc run --rm importer python slurp_api.py containers
-dc run --rm importer python slurp_api.py wells
+dc run --rm importer python slurp_bammens.py container_types
+dc run --rm importer python slurp_bammens.py containers
+dc run --rm importer python slurp_bammens.py wells
 
 # backup raw data for debuging
 dc exec -T database backup-db.sh afvalcontainers

--- a/scrape_api/login.py
+++ b/scrape_api/login.py
@@ -13,7 +13,7 @@ log.setLevel(logging.INFO)
 async def set_login_cookies(session):
     """Get PHPSESSID cookie to use the API
     """
-    baseUrl = settings.API_URL
+    baseUrl = settings.API_BAMMENS_URL
     log.debug("start login")
     loginPage = await session.get(baseUrl + "/login", ssl=True)
     text = await loginPage.text()

--- a/scrape_api/settings.py
+++ b/scrape_api/settings.py
@@ -12,4 +12,5 @@ TESTING = {"running": False}
 # BAMMENS_API_PASSWORD = os.getenv('BAMMENS_API_PASSWORD')
 
 
-API_URL = "https://bammensservice.nl"
+API_BAMMENS_URL = "https://bammensservice.nl"
+API_KILOGRAM_URL = "https://bammensservice.nl"

--- a/scrape_api/slurp_bammens.py
+++ b/scrape_api/slurp_bammens.py
@@ -5,7 +5,6 @@ Save external bammens API container sources
 import aiohttp
 import random
 import time
-import dateparser
 
 # import aiopg
 from aiohttp import ClientSession
@@ -17,10 +16,8 @@ import models
 
 import logging
 import argparse
-import settings
-from settings import API_URL
+from settings import API_BAMMENS_URL as API_URL
 import os.path
-from dateutil import parser
 
 
 import login
@@ -175,7 +172,7 @@ async def do_request(work_id, endpoint, params={}):
             await session.close()
             break
 
-        url = ENDPOINT_URL[endpoint]
+        # url = ENDPOINT_URL[endpoint]
         _id = item["id"]
         json_response = await get_the_json(session, endpoint, _id)
 
@@ -309,7 +306,7 @@ def start_import(endpoint, workers=WORKERS, make_engine=True):
 
 if __name__ == "__main__":
 
-    desc = "Scrape API."
+    desc = "Scrape Bammens API."
     inputparser = argparse.ArgumentParser(desc)
 
     inputparser.add_argument(

--- a/scrape_api/slurp_bammens.py
+++ b/scrape_api/slurp_bammens.py
@@ -25,7 +25,7 @@ from dateutil import parser
 
 import login
 
-log = logging.getLogger("slurp_api")
+log = logging.getLogger("slurp_bammens")
 log.setLevel(logging.INFO)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
 

--- a/scrape_api/sqlcode/create_short_ids.sql
+++ b/scrape_api/sqlcode/create_short_ids.sql
@@ -4,8 +4,10 @@
    this is true in ~200 cases. parks, long weird streets with no houses.
 */
 
+
 update afvalcontainers_site s set
-        short_id = short.short_id
+        short_id = short.short_id,
+        extra_attributes = jsonb_set(extra_attributes, '{chauffeur}', to_jsonb(short.chauffeur))
 from (
 select
     row_number() over (partition by s.straatnaam, s.huisnummer order by s.id) as rown,
@@ -33,7 +35,8 @@ where short.rown = 1 and short.site_id = s.id;
 
 
 update afvalcontainers_site s set
-        short_id = cast(concat(rown, short.short_id) as int)
+        short_id = cast(concat(rown, short.short_id) as int),
+        extra_attributes = jsonb_set(extra_attributes, '{chauffeur}', to_jsonb(short.chauffeur))
 from (
 select
     row_number() over (partition by s.straatnaam, s.huisnummer order by s.id) as rown,
@@ -53,4 +56,28 @@ cross join lateral (select * from afvalcontainers_well w where s.id = w.site_id 
 where o.opr_type = 'Weg'
 ) as short
 where short.rown > 1
-and short.site_id = s.id
+and short.site_id = s.id;
+
+
+update afvalcontainers_site s set
+        short_id = short.short_id
+from (
+select
+    row_number() over (partition by s.straatnaam, s.huisnummer order by s.id) as rown,
+    cast(
+          concat(
+                right(o.id, 5),
+        huisnummer
+      )
+    as int) as short_id,
+    s.id as site_id,
+    straatnaam,
+    huisnummer,
+    distance,
+    o.id as code
+from afvalcontainers_site s
+left outer join openbareruimte o on(s.straatnaam = o.display)
+where o.opr_type = 'Weg'
+and s.short_id = null
+) as short
+where short.site_id = s.id;

--- a/scrape_api/test_slurp_bammens.py
+++ b/scrape_api/test_slurp_bammens.py
@@ -3,10 +3,10 @@ Some tests.
 """
 
 import json
-import time
+# import time
 import unittest
 import asynctest
-import slurp_api
+import slurp_bammens
 import models
 import logging
 from settings import BASE_DIR
@@ -58,8 +58,8 @@ class TestDBWriting(unittest.TestCase):
     Test writing to database
     """
 
-    @asynctest.patch("slurp_api.get_the_json")
-    @asynctest.patch("slurp_api.fetch")
+    @asynctest.patch("slurp_bammens.get_the_json")
+    @asynctest.patch("slurp_bammens.fetch")
     def test_containers(self, fetch_mock, get_json_mock):
 
         with open(FIX_DIR + "/fixtures/containers.json") as detail_json:
@@ -74,12 +74,12 @@ class TestDBWriting(unittest.TestCase):
         get_json_mock.side_effect = detail_json[:6]
         fetch_mock.side_effect = [mr]
 
-        slurp_api.start_import("containers", workers=2, make_engine=False)
+        slurp_bammens.start_import("containers", workers=2, make_engine=False)
         count = session.query(models.Container).count()
         self.assertEqual(count, 5)
 
-    @asynctest.patch("slurp_api.get_the_json")
-    @asynctest.patch("slurp_api.fetch")
+    @asynctest.patch("slurp_bammens.get_the_json")
+    @asynctest.patch("slurp_bammens.fetch")
     def test_wells(self, fetch_mock, get_json_mock):
 
         with open(FIX_DIR + "/fixtures/wells.json") as detail_json:
@@ -94,12 +94,12 @@ class TestDBWriting(unittest.TestCase):
         get_json_mock.side_effect = detail_json[:4]
         fetch_mock.side_effect = [mr]
 
-        slurp_api.start_import("wells", workers=2, make_engine=False)
+        slurp_bammens.start_import("wells", workers=2, make_engine=False)
         count = session.query(models.Well).count()
         self.assertEqual(count, 4)
 
-    @asynctest.patch("slurp_api.get_the_json")
-    @asynctest.patch("slurp_api.fetch")
+    @asynctest.patch("slurp_bammens.get_the_json")
+    @asynctest.patch("slurp_bammens.fetch")
     def test_container_types(self, fetch_mock, get_json_mock):
 
         with open(FIX_DIR + "/fixtures/containertypes.json") as detail_json:
@@ -114,6 +114,7 @@ class TestDBWriting(unittest.TestCase):
         get_json_mock.side_effect = detail_json[:3]
         fetch_mock.side_effect = [mr]
 
-        slurp_api.start_import("container_types", workers=2, make_engine=False)
+        slurp_bammens.start_import(
+            "container_types", workers=2, make_engine=False)
         count = session.query(models.ContainerType).count()
         self.assertEqual(count, 3)


### PR DESCRIPTION
sites need short_ids even when there a no containers in them.