### PR TITLE
Hotfix voor missende data van kilogram-leverancier

### DIFF
--- a/scrape_api/kilogram/copy_to_model.py
+++ b/scrape_api/kilogram/copy_to_model.py
@@ -124,7 +124,7 @@ def validate_fractie(measurement, idx):
     fractie = 'Rest'
 
     if idx.fractie:
-        fractie = measurement[idx.fractie]
+        fractie = idx.fractie
 
     fractie = FRACTIE_MAPPING.get(fractie, fractie)
 
@@ -193,11 +193,11 @@ def make_field_mapping(fields, system_id):
         date=fields.index('Date'),
         time=fields.index('Time'),
         site_id=fields.index('CustId'),
-        district=fields.index('District'),
-        container_ids=fields.index('ContIds'),
-        container_count=fields.index('NoOfCont'),
-        volume=fields.index('TotalVolume'),
-        neighborhood=fields.index('Neighborhood'),
+       # district=fields.index('District'),
+       # container_ids=fields.index('ContIds'),
+       # container_count=fields.index('NoOfCont'),
+       # volume=fields.index('TotalVolume'),
+       # neighborhood=fields.index('Neighborhood'),
         first_weight=fields.index("FirstWeight"),
         second_weight=fields.index("SecondWeight"),
         net_weight=fields.index("NettWeight"),
@@ -251,16 +251,16 @@ def extract_one_resultset(fields, records, system_id=None):
             'seq_id': measurement[idx._id],
             'weigh_at': weigh_at,
             'system_id': measurement[idx.system_id],
-            'container_ids': measurement[idx.container_ids],
-            'container_count': measurement[idx.container_count],
+  #          'container_ids': measurement[idx.container_ids],
+   #         'container_count': measurement[idx.container_count],
             'fractie': fractie,
             'first_weight': first_weight,
             'fill_level': fill_level,
             'fill_chance': fill_chance,
             'second_weight': second_weight,
             'net_weight': net_weight,
-            'district': measurement[idx.district],
-            'neighborhood': measurement[idx.neighborhood],
+#            'district': measurement[idx.district],
+ #           'neighborhood': measurement[idx.neighborhood],
             'location': location,
             'site_id': site_id,
             'valid': valid,

--- a/scrape_api/kilogram/slurp.py
+++ b/scrape_api/kilogram/slurp.py
@@ -15,7 +15,7 @@ from settings import KILO_ENVIRONMENT_OVERRIDES
 import db_helper
 from kilogram import models
 
-log = logging.getLogger("slurp_bammens")
+log = logging.getLogger("slurp_kilogram")
 log.setLevel(logging.DEBUG)
 logging.getLogger("urllib3").setLevel(logging.DEBUG)
 
@@ -217,24 +217,6 @@ async def load_system_weigh_data(session, system_id):
         body = {
             'request': 'getWeighData',
             'Systems': [int(system_id)],
-            'Fields': [
-                "SystemId",
-                "Seq",
-                "Date",
-                "Time",
-                "CustId",
-                "NoOfCont",
-                "ContIds",
-                "TotalVolume",
-                "District",
-                "Neighborhood",
-                "FractionId",
-                "FirstWeight",
-                "SecondWeight",
-                "NettWeight",
-                "Latitude",
-                "Longitude"
-            ],
             'Limit': 1000
         }
 
@@ -253,6 +235,7 @@ async def load_system_weigh_data(session, system_id):
 
         if not records:
             # no records returned we are done.
+            log.debug("No records returned")
             return
 
         await RESULT_QUEUE.put(json_response)


### PR DESCRIPTION
Onze eigen afvalcontainer API wordt niet meer geupdate door een fout aan de kant van de leverancier. Een aantal velden missen in de levering, maar dat wat noodzakelijk is voor een belangrijke proef die a.s. maandag start is nog wel aanwezig. Deze hotfix zorgt ervoor dat de levering van de noodzakelijke gegevens doorgaat, terwijl de andere gegevens in onze API leeg blijven. De leverancier werkt aan een oplossing.