### PR TITLE
Remove kilgoram raw table from list of tables

### DIFF
--- a/scrape_api/kilogram/models.py
+++ b/scrape_api/kilogram/models.py
@@ -18,7 +18,8 @@ LOG = logging.getLogger(__name__)
 Base = declarative_base()
 
 KILOGRAM_TABLES = [
-    "kilogram_weigh_raw",
+    # Never drop the raw model
+    #  "kilogram_weigh_raw",
     "kilogram_weigh_measurement",
 ]
 


### PR DESCRIPTION
This is as defined in the readme, the raw table keeps the history